### PR TITLE
Add StyleCop rule settings to Code Analysis Ruleset

### DIFF
--- a/ERNI.CodeAnalysis.ruleset
+++ b/ERNI.CodeAnalysis.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="New Rule Set" Description=" " ToolsVersion="14.0">
+<RuleSet Name="ERNI" Description="ERNI coding conventions: https://wiki.erninet.ch/display/ES/C%23+Coding+Conventions" ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1000" Action="Error" />
     <Rule Id="CA1001" Action="Error" />
@@ -583,5 +583,40 @@
     <Rule Id="C6993" Action="Warning" />
     <Rule Id="C6995" Action="Warning" />
     <Rule Id="C6997" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1115" Action="None" />
+    <Rule Id="SA1116" Action="None" />
+    <Rule Id="SA1118" Action="None" />
+    <Rule Id="SA1124" Action="None" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1504" Action="None" />
+    <Rule Id="SA1513" Action="None" />
+    <Rule Id="SA1516" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1604" Action="None" />
+    <Rule Id="SA1605" Action="None" />
+    <Rule Id="SA1606" Action="None" />
+    <Rule Id="SA1607" Action="None" />
+    <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1618" Action="None" />
+    <Rule Id="SA1619" Action="None" />
+    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1634" Action="None" />
+    <Rule Id="SA1635" Action="None" />
+    <Rule Id="SA1637" Action="None" />
+    <Rule Id="SA1640" Action="None" />
+    <Rule Id="SA1642" Action="None" />
+    <Rule Id="SA1643" Action="None" />
+    <Rule Id="SX1309" Action="Warning" />
+    <Rule Id="SX1309S" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,11 @@
+﻿{
+  // This file contains configuration of StyleCop rules
+  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}


### PR DESCRIPTION
In projects using Roslyn compiler it is much easier to use Roslyn analyzers for StyleCop. Analyzers are implemented in project [StyleCopeAnalyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers).
StyleCop checks are treated as any other code analysis, and therefore StyleCop rules must be defined in ruleset file.

There 3 changes in this PR:

- Change name of ruleset to ERNI and add URL of wiki page into description.
- Add exclusion of StyleCop rules into ERNI.CodeAnalysis.ruleset. Ruleset is compatible with Settings.StyleCop file.
- Add stylecop.json. This file contains settings for stylecop analyzers and should be included in C# project using stylecop analyzers. There is only one setting: Put using declarations out of namespace block.